### PR TITLE
Fix window close error

### DIFF
--- a/src/chord/code/electron-main/main.ts
+++ b/src/chord/code/electron-main/main.ts
@@ -36,9 +36,6 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', (event) => {
     logger.info('[event]: before-quit');
-
-    // Send quit signal to chord
-    win.webContents.send('chord-quit', null);
 });
 
 app.on('activate', () => {


### PR DESCRIPTION
Only send `chord-quit` event when window closes.

Fix #28 